### PR TITLE
ci: Add Renovate for automated dependency updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,44 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [ "config:recommended", ":semanticCommits", "replacements:material-ui-to-mui" ],
+  "packageRules": [
+    {
+      "extends": [
+        "monorepo:angular",
+        "monorepo:angular-cli",
+        "monorepo:angular-eslint",
+        "monorepo:angularfire",
+        "monorepo:angularjs",
+        "monorepo:angularmaterial"
+      ],
+      "groupName": "everything angular",
+      "matchUpdateTypes": ["minor", "patch", "digest"],
+      "automerge": true,
+      "automergeType": "branch"
+    },
+    {
+      "extends": [
+        "monorepo:material-ui",
+        "monorepo:material-components-web"
+      ],
+      "groupName": "everything material",
+      "matchUpdateTypes": ["minor", "patch", "digest"],
+      "automerge": true,
+      "automergeType": "branch"
+    },
+    {
+      "extends": [
+        "monorepo:semantic-release"
+      ],
+      "matchUpdateTypes": ["minor", "patch", "digest"],
+      "automerge": true,
+      "automergeType": "branch"
+    }
+  ],
+  "platformAutomerge": true,
+  "lockFileMaintenance": {
+    "enabled": true,
+    "automerge": true,
+    "automergeType": "branch"
+  }
+}


### PR DESCRIPTION
Automate production and dev dependency updates. This allows renovate to automatically merge digest, patch, and minor updates to Angular, Semantic Release, and Material dependencies.
